### PR TITLE
Improved display and line editing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ if (EXISTS ${picoVscode})
     include(${picoVscode})
 endif()
 # ====================================================================================
-set(PICO_BOARD pico2_w CACHE STRING "Board type")
+set(PICO_BOARD pico CACHE STRING "Board type")
 
 # Pull in Raspberry Pi Pico SDK (must be before project)
 include(pico_sdk_import.cmake)
@@ -87,7 +87,7 @@ add_executable(picocalc-frotz
 )
 
 pico_set_program_name(picocalc-frotz "picocalc-frotz")
-pico_set_program_version(picocalc-frotz "0.1")
+pico_set_program_version(picocalc-frotz "0.2")
 
 # Generate PIO header
 pico_generate_pio_header(picocalc-frotz ${CMAKE_CURRENT_LIST_DIR}/modules/picocalc-text-starter/drivers/audio.pio)

--- a/README.md
+++ b/README.md
@@ -4,6 +4,24 @@ This is an unofficial port of Frotz to the PicoCalc. Frotz has been actively dev
 
 This project adds a small amount of code to integrate the included modules. Each module (picocalc-text-starter and frotz), which are unmodified, work together to provide a complete experience for playing Z-Machine games on the PicoCalc.
 
+> [!NOTE]
+> This project is not affiliated with the original Frotz project or its developers. It is a port to the PicoCalc platform, which is based on the Pico-series microcontrollers.
+
+
+# Features
+
+- Play Z-Machine games on the PicoCalc
+- Supports the PicoCalc's LCD display, keyboard, audio output and SD card
+- Provides a 40x32 character display with an easy to read font
+- Emulates a phosphor display, with white, green or amber phosphor (F10 to cycle through modes)
+- Full line editing including history
+- Store stories on an SD card in the Stories directory (`/Stories`)
+- Includes a simple story selector to choose which story to play
+- Supports saving and restoring, quitting and restarting stories
+
+> [!TIP]
+> The phosphor display is a visual effect that simulates the look of an old CRT display. It can be cycled any point during gameplay by pressing F10. The story selector is fixed to the white phosphor.
+
 # Getting Started
 
 Flash the PicoCalc with the latest release and reboot your PicoCalc.
@@ -11,7 +29,7 @@ Flash the PicoCalc with the latest release and reboot your PicoCalc.
 A simple story selector is presented when you turn on the PicoCalc. This lists the stories stored in the `/stories` directory on the SD card. You select a story to play, and press enter to begin.
 
 > [!TIP]
->A Pico 2 (W) or other RP2350-based device is highly recommended. The stories are loaded from the SD card into RAM. The RP2350-based boards have 520 KiB of RAM over the RP2040's 264 KiB, which allows for larger stories to be loaded.
+>A Pico 2 (W) or other RP2350-based device is recommended. The stories are loaded from the SD card into RAM. The RP2350-based boards have 520 KiB of RAM over the RP2040's 264 KiB, which allows for larger stories to be loaded. Saying that, many stories from Infocom will play on a Pico 1.
 
 # Modules
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This project adds a small amount of code to integrate the included modules. Each
 - Supports the PicoCalc's LCD display, keyboard, audio output and SD card
 - Provides a 40x32 character display with an easy to read font
 - Emulates a phosphor display, with white, green or amber phosphor (F10 to cycle through modes)
-- Full line editing including history
+- Full line editing including history and tab completion
 - Store stories on an SD card in the Stories directory (`/Stories`)
 - Includes a simple story selector to choose which story to play
 - Supports saving and restoring, quitting and restarting stories

--- a/defs.h
+++ b/defs.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#define VERSION "2.50"
+#define VERSION "2.55"
 #define RELEASE_NOTES "Unofficial PicoCalc Frotz Port"
 
 /* Basic configuration for embedded/PicoCalc build */

--- a/hash.h
+++ b/hash.h
@@ -1,11 +1,5 @@
 #pragma once
 
-#ifndef VERSION
-#define VERSION "2.50"
-#endif
-#ifndef RELEASE_NOTES
-#define RELEASE_NOTES "UnofficialPicoCalc Frotz Port"
-#endif
 #define GIT_HASH "unknown"
 #define GIT_HASH_SHORT "unknown"
 #define GIT_DATE "unknown"

--- a/picocalc/init.c
+++ b/picocalc/init.c
@@ -171,7 +171,7 @@ bool select_story(void)
 		}
 		else if (ch == ZC_ARROW_DOWN)
 		{
-			if (selected < num_stories)
+			if (selected < num_stories - 1)
 				selected++;
 		}
 		else if (ch == ZC_RETURN)
@@ -287,6 +287,8 @@ int os_random_seed(void)
 
 void os_quit(int status)
 {
+	char buffer[2];
+
 	if (status == EXIT_SUCCESS)
 	{
 		print_string("\n\nGame over. Thanks for playing!\n");
@@ -296,9 +298,9 @@ void os_quit(int status)
 		print_string("\n\nAn error occurred. Please try again.\n");
 	}
 
-	print_string("\nPress any key to select a story, or ");
+	print_string("\nPress ENTER to select a story, or ");
 	print_string("please turn off your PicoCalc now.\n");
-	read_string(0, NULL); // Wait for user input before quitting
+	read_string(1, buffer); // Wait for user input before quitting
 }
 
 void os_restart_game(int UNUSED(stage))
@@ -372,7 +374,7 @@ void os_init_setup(void)
 	audio_init();
 	fat32_init();
 
-	lcd_set_foreground(NORMAL_COLOUR);
+	lcd_set_foreground(DEFAULT_PHOSPHOR);
 	lcd_enable_cursor(false);
 	os_set_cursor(1, 1);
 	os_display_string("Welcome to the Unofficial Port of Frotz!");

--- a/picocalc/input.c
+++ b/picocalc/input.c
@@ -305,7 +305,8 @@ zchar os_read_line(int max, zchar *buf, int timeout, int width, int continued)
 				}
 				strncpy(buf, history_buffer[history_index], max - 1);
 				buf[max - 1] = 0; // Ensure null-termination
-				length = index = strlen(buf);
+				length = strlen(buf);
+				index = length;
 				lcd_erase_cursor();
 				os_set_cursor(row, col);
 				os_display_string(buf);

--- a/picocalc/input.c
+++ b/picocalc/input.c
@@ -215,7 +215,7 @@ zchar os_read_line(int max, zchar *buf, int timeout, int width, int continued)
 					memcpy(buf + index, result, result_length);
 					index += result_length;
 					length += result_length;
-					os_display_string(buf + index - 1); // Redisplay the rest of the line
+					os_display_string(buf + index - result_length); // Redisplay the rest of the line
 					os_set_cursor(row, col + index);
 				}
 			}

--- a/picocalc/output.c
+++ b/picocalc/output.c
@@ -68,6 +68,23 @@ void addch(zchar c)
     lcd_move_cursor(cursor_col, cursor_row);
 }
 
+
+void update_lcd_display(int top, int left, int bottom, int right)
+{
+    // Update the LCD display
+    for (int r = top; r <= bottom; r++)
+    {
+        for (int c = left; c <= right; c++)
+        {
+            uint8_t style = screen[r * SCREEN_WIDTH + c] & 0xFF;
+            lcd_set_reverse(style & REVERSE_STYLE);
+            lcd_set_bold(style & BOLDFACE_STYLE);
+            lcd_set_underscore(style & EMPHASIS_STYLE);
+            lcd_putc(c, r, screen[r * SCREEN_WIDTH + c] >> 16);
+        }
+    }
+}
+
 void os_init_sound(void)
 {
     audio_init();
@@ -233,18 +250,7 @@ void os_scroll_area(int top, int left, int bottom, int right, int units)
         }
     }
 
-    // Update the LCD display
-    for (int r = top; r <= bottom; r++)
-    {
-        for (int c = left; c <= right; c++)
-        {
-            uint8_t style = screen[r * SCREEN_WIDTH + c] & 0xFF;
-            lcd_set_reverse(style & REVERSE_STYLE);
-            lcd_set_bold(style & BOLDFACE_STYLE);
-            lcd_set_underscore(style & EMPHASIS_STYLE);
-            lcd_putc(c, r, screen[r * SCREEN_WIDTH + c] >> 16);
-        }
-    }
+    update_lcd_display(top, left, bottom, right);
 }
 
 int os_font_data(int font, int *height, int *width)

--- a/picocalc/picocalc_frotz.h
+++ b/picocalc/picocalc_frotz.h
@@ -23,12 +23,15 @@
 
 #define SCREEN_WIDTH (40)
 #define SCREEN_HEIGHT (32)
-#define RGB(r,g,b)      ((uint16_t)(((r) >> 3) << 11 | ((g) >> 2) << 5 | ((b) >> 3)))
-#define WHITE_PHOSPHOR  RGB(216, 240, 255)  // white phosphor
-#define GREEN_PHOSPHOR  RGB(51, 255, 102)   // green phosphor
-#define AMBER_PHOSPHOR  RGB(255, 255, 51)   // amber phosphor
-#define BRIGHT_COLOR    RGB(255, 255, 255)  // white
-#define NORMAL_COLOUR   WHITE_PHOSPHOR      // Non-BRIGHT
+
+#define RGB(r,g,b)          ((uint16_t)(((r) >> 3) << 11 | ((g) >> 2) << 5 | ((b) >> 3)))
+#define WHITE_PHOSPHOR      RGB(216, 240, 255)  // white phosphor
+#define GREEN_PHOSPHOR      RGB(51, 255, 51)    // green phosphor
+#define AMBER_PHOSPHOR      RGB(255, 183, 0)    // amber phosphor
+#define DEFAULT_PHOSPHOR    WHITE_PHOSPHOR
+
+#define HISTORY_SIZE 20
+#define HISTORY_LINE_LENGTH 40
 
 /* from ../common/setup.h */
 extern f_setup_t f_setup;


### PR DESCRIPTION
This pull request introduces several updates to enhance functionality, improve user experience, and fix minor issues in the PicoCalc Frotz port. Key changes include improved input handling with features like tab completion and history navigation, updated display color options, and adjustments to project metadata and documentation.

### Input Handling Enhancements:
* Added input history navigation (using arrow keys) and tab completion for command inputs in `picocalc/input.c`. This includes new functions for managing input history and handling various key events. [[1]](diffhunk://#diff-29c0f750a9a35c24cb383976ffc4e0571ce4185f876cbb6eb026178b3c8f642cR55-R65) [[2]](diffhunk://#diff-29c0f750a9a35c24cb383976ffc4e0571ce4185f876cbb6eb026178b3c8f642cR187-R408) [[3]](diffhunk://#diff-29c0f750a9a35c24cb383976ffc4e0571ce4185f876cbb6eb026178b3c8f642cL129-R168)
* Implemented support for additional keys (e.g., Home, End, Delete) in the input handling logic. [[1]](diffhunk://#diff-29c0f750a9a35c24cb383976ffc4e0571ce4185f876cbb6eb026178b3c8f642cR120-R123) [[2]](diffhunk://#diff-29c0f750a9a35c24cb383976ffc4e0571ce4185f876cbb6eb026178b3c8f642cR108-R109)

### Display and Visual Updates:
* Introduced a phosphor display effect with adjustable color modes (white, green, amber) that can be toggled using the F10 key. Updated default phosphor color to white. [[1]](diffhunk://#diff-16bf12d44459bb4f890bf973454cbf6a5b3476a6a09034920668f206229813baR26-R34) [[2]](diffhunk://#diff-29c0f750a9a35c24cb383976ffc4e0571ce4185f876cbb6eb026178b3c8f642cL129-R168) F372R374)
* Refactored display update logic by centralizing it in a new `update_lcd_display` function, improving maintainability. [[1]](diffhunk://#diff-4602d67a41813b03213e65688bc013b08b683e563f9d49120dc7267005c45233R71-R87) [[2]](diffhunk://#diff-4602d67a41813b03213e65688bc013b08b683e563f9d49120dc7267005c45233L236-R253)

### Project Metadata and Versioning:
* Updated project version from `0.1` to `0.2` in `CMakeLists.txt` and from `2.50` to `2.55` in `defs.h`. [[1]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL90-R90) [[2]](diffhunk://#diff-12a8c5d655524983897b7c973aa19f0928bd56a1627daadb63c82f301f32210bL3-R3)
* Adjusted board configuration to use the Pico board instead of Pico 2 in `CMakeLists.txt`.

### Documentation Improvements:
* Expanded the `README.md` with detailed project features, usage tips, and a clarification of its unofficial status.

### Bug Fixes:
* Fixed an off-by-one error in story selection logic within `picocalc/init.c`.
* Adjusted the behavior of `os_quit` to correctly handle user input and improve messaging.

These updates collectively enhance the usability, maintainability, and clarity of the PicoCalc Frotz port.