### PR TITLE
Add 64-column display

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,7 +74,8 @@ add_executable(picocalc-frotz
         modules/picocalc-text-starter/drivers/display.h
         modules/picocalc-text-starter/drivers/fat32.c
         modules/picocalc-text-starter/drivers/fat32.h
-        modules/picocalc-text-starter/drivers/font.c
+        modules/picocalc-text-starter/drivers/font-5x10.c
+        modules/picocalc-text-starter/drivers/font-8x10.c
         modules/picocalc-text-starter/drivers/font.h
         modules/picocalc-text-starter/drivers/keyboard.c
         modules/picocalc-text-starter/drivers/keyboard.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,7 +87,7 @@ add_executable(picocalc-frotz
 )
 
 pico_set_program_name(picocalc-frotz "picocalc-frotz")
-pico_set_program_version(picocalc-frotz "0.2")
+pico_set_program_version(picocalc-frotz "0.3")
 
 # Generate PIO header
 pico_generate_pio_header(picocalc-frotz ${CMAKE_CURRENT_LIST_DIR}/modules/picocalc-text-starter/drivers/audio.pio)

--- a/picocalc/init.c
+++ b/picocalc/init.c
@@ -159,7 +159,7 @@ bool select_story(void)
 
 	do
 	{
-		uint8_t battery_level = sb_read_battery();
+		uint8_t battery_level = sb_read_battery() & 0x7F;
 		os_set_cursor(32, 28);
 		snprintf(buffer, sizeof(buffer), "Battery: %u%%", battery_level);
 		os_display_string(buffer);

--- a/picocalc/init.c
+++ b/picocalc/init.c
@@ -87,8 +87,8 @@ bool select_story(void)
 	// For simplicity, we assume the stories are in a directory called "stories"
 	// In a real application, you would use a filesystem API to list files.
 
-	fat32_dir_t dir;
-	fat32_error_t result = fat32_dir_open(&dir, "/Stories");
+	fat32_file_t dir;
+	fat32_error_t result = fat32_open(&dir, "/Stories");
 	if (result != FAT32_OK)
 	{
 		basic_quit("   Error opening /Stories directory!");
@@ -119,7 +119,7 @@ bool select_story(void)
 			}
 		}
 	} while (dir_entry.filename[0]);
-	fat32_dir_close(&dir);
+	fat32_close(&dir);
 
 	if (num_stories == 0)
 	{
@@ -128,7 +128,7 @@ bool select_story(void)
 	else if (num_stories >= 24)
 	{
 		os_set_cursor(32, 1);
-		os_display_string("Only showing the first 24 stories.");
+		os_display_string("Only showing 24 stories.");
 		num_stories = 24;
 	}
 
@@ -159,6 +159,10 @@ bool select_story(void)
 
 	do
 	{
+		uint8_t battery_level = sb_read_battery();
+		os_set_cursor(32, 28);
+		snprintf(buffer, sizeof(buffer), "Battery: %u%%", battery_level);
+		os_display_string(buffer);
 		ch = os_read_key(0, false);
 		os_set_cursor(5 + selected, 2);
 		snprintf(buffer, sizeof(buffer), "%-38s", stories[selected]);

--- a/picocalc/input.c
+++ b/picocalc/input.c
@@ -10,14 +10,9 @@
 #undef bool
 #include "picocalc_frotz.h"
 
-extern f_setup_t f_setup;
-extern int cursor_row, cursor_col;
-extern uint8_t text_style;
-extern void update_lcd_display(int top, int left, int bottom, int right);
-
 volatile bool user_interrupt = FALSE;
 
-char history_buffer[HISTORY_SIZE][HISTORY_LINE_LENGTH] = {0};
+static char history_buffer[HISTORY_SIZE][HISTORY_LINE_LENGTH] = {0};
 static uint8_t history_head = 0;
 static uint8_t history_tail = 0;
 static uint8_t history_index = 0;
@@ -578,7 +573,7 @@ char *os_read_file_name(const char *default_name, int flag)
 
 void os_more_prompt(void)
 {
-	uint8_t saved_style = text_style;
+	uint8_t saved_style = os_get_text_style();
 	int saved_row = cursor_row + 1;
 	int saved_col = cursor_col + 1;
 

--- a/picocalc/pic.c
+++ b/picocalc/pic.c
@@ -4,9 +4,6 @@
 
 #include "picocalc_frotz.h"
 
-extern f_setup_t f_setup;
-extern z_header_t z_header;
-
 bool pc_init_pictures(void)
 {
 	return FALSE;

--- a/picocalc/picocalc_frotz.h
+++ b/picocalc/picocalc_frotz.h
@@ -20,8 +20,7 @@
 #include <time.h>
 
 #include <sys/param.h>
-
-#define SCREEN_WIDTH (40)
+#define MAX_SCREEN_WIDTH (64) // PicoCalc screen width in characters (maximum)
 #define SCREEN_HEIGHT (32)
 
 #define RGB(r,g,b)          ((uint16_t)(((r) >> 3) << 11 | ((g) >> 2) << 5 | ((b) >> 3)))
@@ -33,26 +32,10 @@
 #define HISTORY_SIZE 20
 #define HISTORY_LINE_LENGTH 40
 
-/* from ../common/setup.h */
-extern f_setup_t f_setup;
+// No os_get_cursor() function in Frotz; we need access to the cursor position
+// for input handling.
+extern int cursor_row, cursor_col;
+extern uint8_t columns; // Number of columns in the display
 
-/* From input.c.  */
-bool is_terminator (zchar);
-
-/* pc-input.c */
-bool pc_handle_setting(const char *setting, bool show_cursor, bool startup);
-void pc_init_input(void);
-
-/* pc-output.c */
-void pc_init_output(void);
-bool pc_output_handle_setting(const char *setting, bool show_cursor, bool startup);
-void pc_show_screen(bool show_cursor);
-void pc_show_prompt(bool show_cursor, char line_type);
-void pc_dump_screen(void);
-void pc_display_user_input(char *);
-void pc_discard_old_input(int num_chars);
-void pc_elide_more_prompt(void);
-void pc_set_picture_cell(int row, int col, zchar c);
-
-/* pc-pic.c */
-bool pc_init_pictures(void);
+// Function prototypes
+void update_lcd_display(int top, int left, int bottom, int right);


### PR DESCRIPTION
This pull request introduces several updates to the `picocalc` project, including support for dynamic screen width, improved story selection, and codebase cleanup. The most significant changes involve adding support for switching between 40- and 64-column display modes, enhancing the user experience with new features like phosphor color switching and battery level display, and modernizing the codebase by replacing outdated or redundant elements.

### Display and UI Enhancements:
* Added support for dynamically switching between 40-column and 64-column modes, including updates to the `columns` variable, screen buffer resizing, and font adjustments (`picocalc/init.c`, `picocalc/output.c`, `picocalc/picocalc_frotz.h`) [[1]](diffhunk://#diff-61084c46c7446ac530c0ea1c996d7de261ec76f2f03b9a4bf3e810a581040117L19-R38) [[2]](diffhunk://#diff-4602d67a41813b03213e65688bc013b08b683e563f9d49120dc7267005c45233L25-R31) [[3]](diffhunk://#diff-16bf12d44459bb4f890bf973454cbf6a5b3476a6a09034920668f206229813baL23-R23).
* Introduced phosphor color switching (white, green, amber) via the F10 key, enhancing visual customization (`picocalc/init.c`).
* Displayed battery level on the UI during story selection (`picocalc/init.c`).

### Story Selection Improvements:
* Replaced `fat32_dir_open` with `fat32_open` and updated the corresponding logic for listing and sorting stories (`picocalc/init.c`) [[1]](diffhunk://#diff-61084c46c7446ac530c0ea1c996d7de261ec76f2f03b9a4bf3e810a581040117L86-R89) [[2]](diffhunk://#diff-61084c46c7446ac530c0ea1c996d7de261ec76f2f03b9a4bf3e810a581040117L122-R135).
* Added sorting of story names alphabetically using `qsort` and improved the display format to adapt to the selected column width (`picocalc/init.c`).

### Codebase Modernization:
* Updated the submodule `picocalc-text-starter` to a newer commit for improved dependencies (`modules/picocalc-text-starter`).
* Replaced hardcoded screen width references with the `columns` variable to support dynamic resizing (`picocalc/output.c`) [[1]](diffhunk://#diff-4602d67a41813b03213e65688bc013b08b683e563f9d49120dc7267005c45233L25-R31) [[2]](diffhunk://#diff-4602d67a41813b03213e65688bc013b08b683e563f9d49120dc7267005c45233L56-R62).
* Removed unused `extern` declarations and converted some global variables to `static` for better encapsulation (`picocalc/input.c`, `picocalc/output.c`, `picocalc/init.c`, `picocalc/pic.c`) [[1]](diffhunk://#diff-29c0f750a9a35c24cb383976ffc4e0571ce4185f876cbb6eb026178b3c8f642cL13-R15) [[2]](diffhunk://#diff-4602d67a41813b03213e65688bc013b08b683e563f9d49120dc7267005c45233L12-L13) [[3]](diffhunk://#diff-6e25efe1e1e901a54fe4d9aabba9adffefe87bf54b18c16be279a829877c785aL7-L9).

### Version and Font Updates:
* Updated the program version from `0.2` to `0.3` in `CMakeLists.txt`.
* Replaced `font.c` with `font-5x10.c` and `font-8x10.c` to support multiple font sizes for different column widths (`CMakeLists.txt`).

These changes collectively enhance the functionality, user experience, and maintainability of the `picocalc` project.