### PR TITLE
Update README to reflect support for 64-column display

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This project adds a small amount of code to integrate the included modules. Each
 
 - Play Z-Machine games on the PicoCalc
 - Supports the PicoCalc's LCD display, keyboard, audio output and SD card
-- Provides a 40x32 character display with an easy to read font
+- Provides a 40x32 or 64x32 character display with an easy to read font
 - Emulates a phosphor display, with white, green or amber phosphor (F10 to cycle through modes)
 - Full line editing including history and tab completion
 - Store stories on an SD card in the Stories directory (`/Stories`)


### PR DESCRIPTION
This pull request updates the `README.md` file to reflect a new feature for display options. The most important change is the addition of support for a 64x32 character display, in addition to the existing 40x32 option.

Documentation update:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L15-R15): Updated the description of display capabilities to include support for a 64x32 character display alongside the existing 40x32 option.