### PR TITLE
Add save path settings with directory listing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,7 +99,7 @@ pico_generate_pio_header(picocalc-frotz ${CMAKE_CURRENT_LIST_DIR}/modules/picoca
 
 # Enable the use of the ROSC for random number generation
 target_compile_definitions(picocalc-frotz PRIVATE
-    PICO_STACK_SIZE=4096 # 16 KB stack size
+    PICO_STACK_SIZE=2048 # 8 KB stack size
     )
 
 # Modify the below lines to enable/disable output over UART/USB

--- a/picocalc/init.c
+++ b/picocalc/init.c
@@ -23,7 +23,8 @@
 
 uint8_t columns = 40;
 uint16_t phosphor = DEFAULT_PHOSPHOR; // Default phosphor type
-static char selected_story[64];
+static char selected_story[FAT32_MAX_PATH_LEN] = {0}; // Selected story name
+static char save_path[FAT32_MAX_PATH_LEN] = "/Stories/saves"; // Default save path
 
 // Function to handle system exit
 void _exit(int status)
@@ -265,6 +266,8 @@ void os_process_arguments(int UNUSED(argc), char *UNUSED(argv[]))
 	f_setup.story_file = strdup((char *)selected_story);
 	f_setup.story_name = strdup(basename((char *)selected_story));
 
+	f_setup.restricted_path = save_path; // Set the restricted path for file operations
+
 	// Now strip off the extension
 	p = strrchr(f_setup.story_name, '.');
 	if (p != NULL)
@@ -478,6 +481,7 @@ void os_init_setup(void)
 		// Load settings from the INI file
 		const char *phosphor_setting = iniparser_getstring(ini, "default:phosphor", "white");
 		const char *width_setting = iniparser_getstring(ini, "default:columns", "40");
+		const char *save_path = iniparser_getstring(ini, "default:savepath", "/Stories/saves");
 
 		configure_display(phosphor_setting, width_setting);
 	}
@@ -503,7 +507,12 @@ void os_init_setup(void)
 		snprintf(key, sizeof(key), "%s:columns", story_filename);
 		const char *width_setting = iniparser_getstring(ini, key, NULL);
 
+		snprintf(key, sizeof(key), "%s:savepath", story_filename);
+		const char *save_path_setting = iniparser_getstring(ini, key, save_path);
+
 		configure_display(phosphor_setting, width_setting);
+		strncpy(save_path, save_path_setting, sizeof(save_path) - 1);
+		save_path[sizeof(save_path) - 1] = '\0'; // Ensure null-termination	
 
 		iniparser_freedict(ini);
 	}

--- a/picocalc/input.c
+++ b/picocalc/input.c
@@ -577,7 +577,7 @@ char *os_read_file_name(const char *default_name, int flag)
 		{
 			strncat(file_name, path_separator, FAT32_MAX_PATH_LEN - strlen(file_name) - 2);
 		}
-		strncat(file_name, tempname, strlen(file_name) - strlen(tempname) - 1);
+		strncat(file_name, tempname, FAT32_MAX_PATH_LEN - strlen(file_name) - 1);
 	}
 
 	ext = strrchr(file_name, '.');

--- a/picocalc/input.c
+++ b/picocalc/input.c
@@ -501,7 +501,7 @@ char *os_read_file_name(const char *default_name, int flag)
 						{
 							if (dir_entry.attr & (FAT32_ATTR_VOLUME_ID | FAT32_ATTR_HIDDEN | FAT32_ATTR_SYSTEM | FAT32_ATTR_DIRECTORY))
 							{
-								// It's a volume label, hidden file, or system file, skip it
+								// It's a volume label, hidden file, directory, or system file, skip it
 								continue;
 							}
 							else

--- a/picocalc/input.c
+++ b/picocalc/input.c
@@ -511,7 +511,6 @@ char *os_read_file_name(const char *default_name, int flag)
 								print_string("\n");
 								if (++count % (z_header.screen_rows - 1) == 0)
 								{
-									count++;		  // Increment count for the next line
 									os_more_prompt(); // Pause every 24 entries
 								}
 							}

--- a/settings.ini
+++ b/settings.ini
@@ -9,14 +9,21 @@ phosphor=white
 # columns=40|64
 columns=40
 
+# Save path for saved games
+# savepath=/path/to/save
+savepath=/Stories/saves
+
 [Sampler1.z5]
 phosphor=green
 columns=64
+savepath=/Stories/saves/Sampler1
 
 [Sampler2.z3]
 phosphor=amber
 columns=64
+savepath=/Stories/saves/Sampler2
 
 [Tutorial.z3]
 phosphor=white
 columns=64
+savepath=/Stories/saves/Tutorial


### PR DESCRIPTION
This pull request introduces enhancements to file handling and configuration in the `picocalc` project. Key updates include adding support for a restricted save path, improving file name handling with FAT32 path length limits, and updating configuration options to allow per-story save paths. These changes improve usability, particularly around saved game management.

### File Handling Enhancements:
* Added a `restricted_path` field in `os_process_arguments` to enforce a save path for file operations (`picocalc/init.c`, [picocalc/init.cR269-R270](diffhunk://#diff-61084c46c7446ac530c0ea1c996d7de261ec76f2f03b9a4bf3e810a581040117R269-R270)).
* Updated `os_read_file_name` to support FAT32 path length limits (`FAT32_MAX_PATH_LEN`) and display a list of files when the user inputs `?`. This includes filtering out hidden/system files and directories (`picocalc/input.c`, Ffc7e071L432R533, [picocalc/input.cL465-R525](diffhunk://#diff-29c0f750a9a35c24cb383976ffc4e0571ce4185f876cbb6eb026178b3c8f642cL465-R525)).

### Configuration Updates:
* Introduced a `savepath` setting in `settings.ini` to specify default and per-story save paths (`settings.ini`, [settings.iniR12-R29](diffhunk://#diff-f247846b0ab6c196467cd7e8e41027c7f27eb2b74b2e9a33d54c59a6fe9f00b0R12-R29)).
* Modified `os_init_setup` to load the `savepath` setting from the configuration file and ensure it is applied correctly (`picocalc/init.c`, [[1]](diffhunk://#diff-61084c46c7446ac530c0ea1c996d7de261ec76f2f03b9a4bf3e810a581040117R484) [[2]](diffhunk://#diff-61084c46c7446ac530c0ea1c996d7de261ec76f2f03b9a4bf3e810a581040117R510-R515).

### Code Refinements:
* Replaced fixed-size arrays for file paths (e.g., `selected_story`) with `FAT32_MAX_PATH_LEN` to handle longer paths safely (`picocalc/init.c`, [picocalc/init.cL26-R27](diffhunk://#diff-61084c46c7446ac530c0ea1c996d7de261ec76f2f03b9a4bf3e810a581040117L26-R27)).
* Adjusted stack size for `picocalc-frotz` from 16 KB to 8 KB to optimize memory usage (`CMakeLists.txt`, [CMakeLists.txtL102-R102](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL102-R102)).