### PR TITLE
Update to the latest picocalc-text-starter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,7 +92,7 @@ add_executable(picocalc-frotz
 )
 
 pico_set_program_name(picocalc-frotz "picocalc-frotz")
-pico_set_program_version(picocalc-frotz "0.4")
+pico_set_program_version(picocalc-frotz "0.5")
 
 # Generate PIO header
 pico_generate_pio_header(picocalc-frotz ${CMAKE_CURRENT_LIST_DIR}/modules/picocalc-text-starter/drivers/audio.pio)


### PR DESCRIPTION
This pull request includes updates to the `picocalc-frotz` project, focusing on versioning and submodule updates.

### Versioning Updates:
* Updated the program version for `picocalc-frotz` from `0.4` to `0.5` in `CMakeLists.txt`.

### Submodule Updates:
* Updated the submodule `modules/picocalc-text-starter` to a new commit (`bb9506bcea0ab28a695ce93a5cbab51538e15530`).